### PR TITLE
define initial module

### DIFF
--- a/.infra/gcp-gh-environment-app-opentofu/terragrunt.hcl
+++ b/.infra/gcp-gh-environment-app-opentofu/terragrunt.hcl
@@ -1,0 +1,29 @@
+include {
+  path = find_in_parent_folders()
+}
+
+locals {
+  gcp_project = read_terragrunt_config(find_in_parent_folders("terragrunt.hcl")).locals.gcp_project
+  gcp_region  = lower(read_terragrunt_config(find_in_parent_folders("terragrunt.hcl")).locals.gcp_region)
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+provider "google" {
+  project       = "${local.gcp_project}"
+  region        = "${local.gcp_region}"
+  // Token comes from GOOGLE_OAUTH_ACCESS_TOKEN env var
+}
+EOF
+}
+
+terraform {
+  source = "../../" // Path to the repository root
+}
+
+inputs = {
+  gcp_project = local.gcp_project
+  gcp_region  = local.gcp_region
+}

--- a/.infra/terragrunt.hcl
+++ b/.infra/terragrunt.hcl
@@ -1,0 +1,26 @@
+locals {
+  state_bucket_name = "${local.github_repo}-opentofu-state"
+  gcp_project = "gh-environment-app-opentofu"
+  gcp_region = "US-WEST1"
+  github_repo = "rcwbr/gh-environment-app-opentofu"
+}
+
+remote_state {
+  backend = "gcs"
+  generate = {
+    path      = "backend.tf"
+    if_exists = "overwrite_terragrunt"
+  }
+  config = {
+    bucket = local.state_bucket_name
+    prefix = "${path_relative_to_include()}"
+    project = local.gcp_project
+    location = local.gcp_region
+    access_token = get_env("GOOGLE_OAUTH_ACCESS_TOKEN", "")
+  }
+}
+
+inputs = {
+  github_repo = local.github_repo
+  state_bucket_name = local.state_bucket_name
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Eric Weber
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # gh-environment-app-opentofu
+
 OpenTofu module to define a GitHub App and environment with access to act as that App

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+


### PR DESCRIPTION
Closes #4 

> ## What
> 
> Define OpenTofu module with a GitHub App and environment with access to act as the App
> 
> ## Why
> 
> Some repo workflows with ref protection settings should allow bypass of those settings only by CI actions in protected contexts. This is achievable by defining an App, accessible only to those protected contexts, that is excluded from protection restrictions.
> 
> ## How
> 
> Leverage [`github_repository_environment` resource](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository_environment), [`github_actions_environment_secret ` resource](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/actions_environment_secret), and [`github_app` data](https://registry.terraform.io/providers/integrations/github/latest/docs/data-sources/app) objects. Also leverage [Probot GitHub App manifests](https://docs.github.com/en/apps/sharing-github-apps/registering-a-github-app-from-a-manifest#about-github-app-manifests) as App registration is not supported by the GitHub TF provider
> 